### PR TITLE
Make Make `ZipfDistribution` generic over `T` and `impl Distribution<T>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 rand = { version = "0.8.0", default-features = false }
+num = "0.4"
 
 [dev-dependencies]
 rand = "0.8.0"


### PR DESCRIPTION
Previously `ZipfDistribution` only generate values of `usize`. This patch introduce a generic type parameter `T` to allow `ZipfDistribution` generating any primitive type value.

This patch makes this crate more helpful.