### PR TITLE
Fix bias towards first element due to floor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,8 @@ impl ZipfDistribution {
             // Limit k to the range [1, num_elements] if it would be outside
             // due to numerical inaccuracies.
             let k64 = x.max(1.0).min(self.num_elements);
-            // float -> integer rounds towards zero,
-            // adding 0.5 ensures a proper round in order to prevent
-            // bias towards k == 1
+            // float -> integer rounds towards zero, so we add 0.5
+            // to prevent bias towards k == 1
             let k = cmp::max(1, (k64 + 0.5) as usize);
 
             // Here, the distribution of k is given by:


### PR DESCRIPTION
This PR addresses a correctness issue where the generator favors the first element more than it should and emits the last element less than it should for a given exponent. This is due to the implicit use of `floor` which makes emitting the last element only possible by an exact match. We thus shift the likelihoods from the first element (which was favored) to the last by adding `0.5` before doing `floor` as the original code [also does](https://github.com/apache/commons-rng/blob/6a1b0c16090912e8fc5de2c1fb5bd8490ac14699/commons-rng-sampling/src/main/java/org/apache/commons/rng/sampling/distribution/RejectionInversionZipfSampler.java#L101).

Also @jonhoo thank you a lot for the crate! Stumbled upon this while porting it to Julia and figured that the fix would be beneficial here too!
